### PR TITLE
Fix large player sprite; add debug draw

### DIFF
--- a/player_sprite.rb
+++ b/player_sprite.rb
@@ -54,5 +54,6 @@ class PlayerSprite
     else
       image.draw @x + @width, @y, 1, -1, 1
     end
+    debug_draw @window
   end
 end

--- a/player_sprite.rb
+++ b/player_sprite.rb
@@ -24,6 +24,22 @@ class PlayerSprite
     @moving = false
   end
 
+  def x_min
+    @x + 25
+  end
+
+  def y_min
+    @y + 25
+  end
+
+  def x_max
+    @x + @width - 25
+  end
+
+  def y_max
+    @y + @height - 25
+  end
+
   def update
     @frame += 1
     @moving = false

--- a/rbcgame.rb
+++ b/rbcgame.rb
@@ -8,6 +8,8 @@ require_relative './floor_sprite.rb'
 require_relative './wall_sprite.rb'
 require_relative './game_state.rb'
 
+DEBUG_DRAW = false
+
 class RBCGame < Gosu::Window
   @walls = []
   attr_reader :game_state

--- a/rectangle.rb
+++ b/rectangle.rb
@@ -1,6 +1,30 @@
 module Occupies
+  def x_min
+    @x
+  end
+  def y_min
+    @y
+  end
+  def x_max
+    @x + @width
+  end
+
+  def y_max
+    @y + @height
+  end
+
   def rectangle
-    Rectangle.new  x_min: @x, x_max: @x + @width, y_min: @y, y_max: @y + @height
+    Rectangle.new  x_min: x_min, x_max: x_max, y_min: y_min, y_max: y_max
+  end
+
+  def debug_draw(window)
+    color = Gosu::Color.argb(0xffff00ff)
+    #draw_line(x1, y1, c1, x2, y2, c2, z = 0, mode = :default) ⇒ void
+    window.draw_line(x_min, y_min, color, x_min, y_max, color)
+    window.draw_line(x_max, y_min, color, x_max, y_max, color)
+    window.draw_line(x_min, y_max, color, x_max, y_max, color)
+    window.draw_line(x_min, y_min, color, x_max, y_min, color)
+
   end
 end
 

--- a/rectangle.rb
+++ b/rectangle.rb
@@ -2,9 +2,11 @@ module Occupies
   def x_min
     @x
   end
+
   def y_min
     @y
   end
+
   def x_max
     @x + @width
   end
@@ -18,8 +20,11 @@ module Occupies
   end
 
   def debug_draw(window)
+    return unless DEBUG_DRAW
+
     color = Gosu::Color.argb(0xffff00ff)
-    #draw_line(x1, y1, c1, x2, y2, c2, z = 0, mode = :default) ⇒ void
+    # from the Gosu docs:
+    # draw_line(x1, y1, c1, x2, y2, c2, z = 0, mode = :default) ==> void
     window.draw_line(x_min, y_min, color, x_min, y_max, color)
     window.draw_line(x_max, y_min, color, x_max, y_max, color)
     window.draw_line(x_min, y_max, color, x_max, y_max, color)

--- a/wall_sprite.rb
+++ b/wall_sprite.rb
@@ -19,5 +19,6 @@ class WallSprite
 
   def draw
     @image[1].draw @x, @y, 1
+    debug_draw @window
   end
 end


### PR DESCRIPTION
The player sprites image has some transparency around it.
It will detect collisions early if we use the true edge of the
image. This overrides the rectangle methods to draw a smaller
rectangle around the picture.

Also, the putting DEBUG_DRAW = true at the top of the file will throw a pink rectangle around all the sprites.